### PR TITLE
copy edits; added that appID can be 3 characters (new)

### DIFF
--- a/docs/appid.md
+++ b/docs/appid.md
@@ -3,9 +3,9 @@ id: appid
 title: appID
 ---
 
-An `appID` is a unique identifier assigned to you by Kin and automatically added to the memo field of each transaction added to the Kin Blockchain by your users. When the Kin Rewards Engine goes live your `appID` will be used to credit you with the activity your application generates so you can be rewarded.
+An `appID` is a unique identifier assigned to you by Kin. When Kin SDK clients are initialized with an appID string, it will be automatically added to the memo field of each transaction on the Kin Blockchain by your users. When the Kin Rewards Engine goes live your `appID` will be used to track the activity your application generates so you can be rewarded.
 
-The `appID` string is four UTF-8 characters containing only digits and upper and/or lower case letters. While you are testing your integration in the Kin Playground environment you can use any string of four characters as long as you only use digits and upper or lower case letters.
+The `appID` string is a three or four UTF-8 characters string containing only digits and upper and/or lower case letters. While you are testing your integration in the Kin Playground environment you can use any valid string as long as you only use digits and upper or lower case letters.
 
 If you manage more than one application, you have the option to use a different `appID`for each one.
 

--- a/docs/appid.md
+++ b/docs/appid.md
@@ -3,9 +3,9 @@ id: appid
 title: appID
 ---
 
-An `appID` is a unique identifier assigned to you by Kin. When Kin SDK clients are initialized with an appID string, it will be automatically added to the memo field of each transaction on the Kin Blockchain by your users. When the Kin Rewards Engine goes live your `appID` will be used to track the activity your application generates so you can be rewarded.
+An `appID` is a unique identifier assigned to you by Kin. When you initialize your Kin SDK clients with your `appID` string, it will be automatically added to the memo field of each transaction added to the Kin Blockchain by your users. When the Kin Rewards Engine goes live your `appID` will be used to track the activity your application generates so you can be rewarded.
 
-The `appID` string is a three or four UTF-8 characters string containing only digits and upper and/or lower case letters. While you are testing your integration in the Kin Playground environment you can use any valid string as long as you only use digits and upper or lower case letters.
+The `appID` string consists of three or four UTF-8 characters containing only digits and upper and/or lower case letters. While you are testing your integration in the Kin Playground environment you can use any valid string as long as you only use digits and upper or lower case letters.
 
 If you manage more than one application, you have the option to use a different `appID`for each one.
 


### PR DESCRIPTION
I made some small copy edits, but some notable changes:

1. appID can actually be 3 or 4 characters, a change was made recently
1. I changed "credit" to "track", when reading credit it gave me a sense that I immediately get some sort of monetary credit, while what the KRE does is track all transactions, apply some magic math and calculate the reward for developers. I thought using tracking was clearer.
1. I wanted to make it clear that in order to have the appID added to the memo the developer must initialize the KinClient with the parameter and THEN it's added. It almost sounded like as long as I have the appID, it'll be added. We might want to add an example, something like "in Android this is how you do it" and leave it to the student to figure out the other languages
